### PR TITLE
Add GitHub Actions workflow for Docker build and publish to GHCR

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,49 @@
+# GitHub Actions Workflows
+
+## Docker Build and Publish Workflow
+
+The `docker-build-publish.yml` workflow automates the process of building and publishing Docker images to GitHub Container Registry (GHCR) for this project.
+
+### Workflow Triggers
+
+The workflow runs in the following scenarios:
+- When a new release is published
+- Manually via workflow dispatch (with an optional version parameter)
+
+### What the Workflow Does
+
+1. Checks out the repository code
+2. Sets up .NET environment
+3. Determines the version to use:
+   - From the release tag if triggered by a release
+   - From the input parameter if manually triggered
+   - From the latest release if no version is specified
+4. Downloads the Linux binary from the corresponding release
+5. Builds the Docker image using the Dockerfile in the Docker directory
+6. Pushes the image to GitHub Container Registry with tags:
+   - `latest`
+   - The specific version number
+
+### Using the Published Docker Image
+
+The Docker image is published to:
+```
+ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest
+ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:[version]
+```
+
+See the [Docker Instructions](../Docker/Docker%20Instructions.md) for details on how to use the image.
+
+### Manual Workflow Trigger
+
+To manually trigger this workflow:
+1. Go to the "Actions" tab in the repository
+2. Select "Build and Publish Docker Image" workflow
+3. Click "Run workflow"
+4. Optionally specify a version tag (without the 'v' prefix)
+5. Click "Run workflow"
+
+### Requirements
+
+- The repository must have releases with Linux binaries available
+- The workflow uses the `GITHUB_TOKEN` which is automatically provided by GitHub Actions

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,0 +1,81 @@
+name: Build and Publish Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (leave empty to use latest release)'
+        required: false
+        default: ''
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Get version
+        id: get-version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.version }}" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          else
+            # Get latest release version if not specified
+            VERSION=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+            VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Download Linux binary
+        run: |
+          mkdir -p ./temp
+          DOWNLOAD_URL=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/v${{ env.VERSION }} | jq -r '.assets[] | select(.name | contains("linux-x64")) | .browser_download_url')
+          if [ -z "$DOWNLOAD_URL" ]; then
+            echo "Could not find Linux binary in release v${{ env.VERSION }}"
+            exit 1
+          fi
+          echo "Downloading from: $DOWNLOAD_URL"
+          curl -L -o ./temp/linux-binary.zip "$DOWNLOAD_URL"
+          unzip -o ./temp/linux-binary.zip -d ./temp/
+          cp ./temp/RewindSubtitleDisplayerForPlex_*_linux-x64 ./Docker/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Docker
+          file: ./Docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/plex-show-subtitles-on-rewind:latest
+            ghcr.io/${{ github.repository_owner }}/plex-show-subtitles-on-rewind:${{ env.VERSION }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.created=${{ github.event.release.published_at || github.event.repository.updated_at }}
+            org.opencontainers.image.version=${{ env.VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Docker/Docker Instructions.md
+++ b/Docker/Docker Instructions.md
@@ -1,6 +1,45 @@
 # Docker Instructions for RewindSubtitleDisplayerForPlex
 
-**Note:** This is a basic Docker setup requiring manual steps. A fully automated build process is not yet implemented.
+## Option 1: Use Pre-built Image from GitHub Container Registry (Recommended)
+
+The easiest way to run this application in Docker is to use the pre-built image from GitHub Container Registry:
+
+```bash
+# Pull the image
+docker pull ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest
+
+# Create a config directory
+mkdir -p ./config
+
+# Run the container
+docker run -d \
+  --name plex-subtitles \
+  -v ./config:/app/config \
+  ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest -auth-device-name Docker
+```
+
+Or with docker-compose:
+
+```yaml
+version: '3.8'
+
+services:
+  plex-rewind-subtitle-displayer:
+    image: ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest
+    container_name: plex_subtitle_displayer
+    restart: unless-stopped
+    volumes:
+      - ./config:/app/config
+    command:
+      - "-auth-device-name"
+      - "Docker"
+```
+
+Then follow steps 4-7 in the manual setup instructions below to complete the configuration.
+
+## Option 2: Manual Setup
+
+**Note:** This is a basic Docker setup requiring manual steps if you prefer to build the image yourself.
 
 **Prerequisites:**
 * Docker Desktop (or Docker Engine with Docker Compose) installed and running.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,44 @@ Once playback reaches the point where you started the rewind, it will **automati
 
 ### **Q:** Is there docker support?
 
-**A:** Yes but at the moment you'll need to set it up with some manual steps. There are instructions [here](https://github.com/ThioJoe/Plex-Show-Subtitles-On-Rewind/blob/master/Docker/Docker%20Instructions.md) and also see [this wiki article](https://github.com/ThioJoe/Plex-Show-Subtitles-On-Rewind/wiki/Running-it-On-a-NAS-in-Docker) for specific instructions for setup in Docker on a NAS
+**A:** Yes! You can use the Docker image from GitHub Container Registry (GHCR) or set it up manually:
+
+#### Option 1: Use the pre-built image from GHCR (recommended)
+
+```bash
+# Pull the image
+docker pull ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest
+
+# Create a config directory
+mkdir -p ./config
+
+# Run the container
+docker run -d \
+  --name plex-subtitles \
+  -v ./config:/app/config \
+  ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest -auth-device-name Docker
+```
+
+Or with docker-compose:
+
+```yaml
+version: '3.8'
+
+services:
+  plex-rewind-subtitle-displayer:
+    image: ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest
+    container_name: plex_subtitle_displayer
+    restart: unless-stopped
+    volumes:
+      - ./config:/app/config
+    command:
+      - "-auth-device-name"
+      - "Docker"
+```
+
+#### Option 2: Manual setup
+
+For manual setup, follow the instructions [here](https://github.com/ThioJoe/Plex-Show-Subtitles-On-Rewind/blob/master/Docker/Docker%20Instructions.md) and also see [this wiki article](https://github.com/ThioJoe/Plex-Show-Subtitles-On-Rewind/wiki/Running-it-On-a-NAS-in-Docker) for specific instructions for setup in Docker on a NAS.
 
 ### **Q: What platforms are supported?**
 


### PR DESCRIPTION
## Description

This PR adds a GitHub Actions workflow to automatically build Docker images and publish them to GitHub Container Registry (GHCR) when a new release is published or when manually triggered.

### Changes

- Added `.github/workflows/docker-build-publish.yml` workflow file that:
  - Triggers on new releases or manual workflow dispatch
  - Downloads the Linux binary from the corresponding release
  - Builds the Docker image using the existing Dockerfile
  - Pushes the image to GHCR with both `latest` and version-specific tags
- Updated `README.md` to include instructions for using the Docker image from GHCR
- Updated `Docker/Docker Instructions.md` to mention the pre-built image option
- Added `.github/workflows/README.md` with documentation about the workflow

### Benefits

- Eliminates the need for manual Docker image building
- Provides an official, versioned Docker image for users
- Makes it easier for users to run the application in Docker environments

### Testing

The workflow will be tested when the next release is published or when manually triggered after this PR is merged.