### PR TITLE
Add build and release workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,5 +1,25 @@
 # GitHub Actions Workflows
 
+This directory contains GitHub Actions workflows for automating the build, release, and Docker image publishing processes.
+
+## Build and Release Workflow
+
+The `build-and-release.yml` workflow automates the process of building the application for multiple platforms and creating a GitHub release with the binaries.
+
+### How to use:
+
+1. Go to the "Actions" tab in the GitHub repository
+2. Select the "Build and Release" workflow
+3. Click "Run workflow"
+4. Enter the version number (e.g., `1.0.0`) and select whether it's a pre-release
+5. Click "Run workflow"
+
+The workflow will:
+- Build the application for Windows, Linux, and macOS
+- Create a GitHub release with the specified version
+- Upload the binaries to the release
+- Add release notes with download links
+
 ## Docker Build and Publish Workflow
 
 The `docker-build-publish.yml` workflow automates the process of building and publishing Docker images to GitHub Container Registry (GHCR) for this project.

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,94 @@
+name: Build and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.0.0)'
+        required: true
+      prerelease:
+        description: 'Is this a pre-release?'
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build for Windows (x64)
+        run: |
+          dotnet publish -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:Version=${{ github.event.inputs.version }}
+
+      - name: Build for Linux (x64)
+        run: |
+          dotnet publish -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:Version=${{ github.event.inputs.version }}
+
+      - name: Build for macOS (x64)
+        run: |
+          dotnet publish -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=true -p:Version=${{ github.event.inputs.version }}
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          
+          # Windows
+          if [ -f "bin/Release/net9.0/win-x64/publish/RewindSubtitleDisplayerForPlex.exe" ]; then
+            cp bin/Release/net9.0/win-x64/publish/RewindSubtitleDisplayerForPlex.exe release-assets/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_win-x64.exe
+          fi
+          
+          # Linux
+          if [ -f "bin/Release/net9.0/linux-x64/publish/RewindSubtitleDisplayerForPlex" ]; then
+            cp bin/Release/net9.0/linux-x64/publish/RewindSubtitleDisplayerForPlex release-assets/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_linux-x64
+            chmod +x release-assets/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_linux-x64
+          fi
+          
+          # macOS
+          if [ -f "bin/Release/net9.0/osx-x64/publish/RewindSubtitleDisplayerForPlex" ]; then
+            cp bin/Release/net9.0/osx-x64/publish/RewindSubtitleDisplayerForPlex release-assets/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_osx-x64
+            chmod +x release-assets/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_osx-x64
+          fi
+          
+          # List the files
+          ls -la release-assets/
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
+          draft: false
+          prerelease: ${{ github.event.inputs.prerelease }}
+          files: |
+            release-assets/*
+          body: |
+            ## Plex Show Subtitles On Rewind v${{ github.event.inputs.version }}
+            
+            ### Downloads
+            - Windows: [RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_win-x64.exe](https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.version }}/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_win-x64.exe)
+            - Linux: [RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_linux-x64](https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.version }}/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_linux-x64)
+            - macOS: [RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_osx-x64](https://github.com/${{ github.repository }}/releases/download/v${{ github.event.inputs.version }}/RewindSubtitleDisplayerForPlex_${{ github.event.inputs.version }}_osx-x64)
+            
+            ### Docker
+            Docker images are automatically built and published to GitHub Container Registry:
+            ```
+            docker pull ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:${{ github.event.inputs.version }}
+            ```
+            or
+            ```
+            docker pull ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind:latest
+            ```

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -56,15 +56,44 @@ jobs:
 
       - name: Download Linux binary
         run: |
-          # For testing purposes, we're using the binary already in the repository
-          # In a real scenario, this would download from the release
-          
-          # Check if the binary already exists in the Docker directory
-          if [ $(find ./Docker -name "RewindSubtitleDisplayerForPlex_*_linux-x64" | wc -l) -gt 0 ]; then
-            echo "Using existing Linux binary in Docker directory"
+          # Download the Linux binary from the release
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            # Get the download URL for the Linux binary
+            DOWNLOAD_URL=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.event.release.tag_name }} | \
+                          jq -r '.assets[] | select(.name | contains("linux-x64")) | .browser_download_url')
+            
+            if [[ -z "$DOWNLOAD_URL" || "$DOWNLOAD_URL" == "null" ]]; then
+              echo "::error::Could not find Linux binary in release ${{ github.event.release.tag_name }}. Make sure the release contains a Linux x64 binary."
+              exit 1
+            fi
+            
+            # Download the binary
+            echo "Downloading Linux binary from $DOWNLOAD_URL"
+            curl -L -o ./Docker/RewindSubtitleDisplayerForPlex_${VERSION}_linux-x64 $DOWNLOAD_URL
+            chmod +x ./Docker/RewindSubtitleDisplayerForPlex_${VERSION}_linux-x64
           else
-            echo "::error::No Linux binary found in Docker directory. This workflow requires a Linux binary."
-            exit 1
+            # For workflow_dispatch, check if the binary already exists in the Docker directory
+            if [ $(find ./Docker -name "RewindSubtitleDisplayerForPlex_*_linux-x64" | wc -l) -gt 0 ]; then
+              echo "Using existing Linux binary in Docker directory"
+            else
+              # Try to download from the latest release
+              LATEST_RELEASE=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest)
+              if [[ $(echo "$LATEST_RELEASE" | jq -r '.message') == "Not Found" ]]; then
+                echo "::error::No releases found in the repository. Please create a release first or provide a Linux binary."
+                exit 1
+              fi
+              
+              DOWNLOAD_URL=$(echo "$LATEST_RELEASE" | jq -r '.assets[] | select(.name | contains("linux-x64")) | .browser_download_url')
+              if [[ -z "$DOWNLOAD_URL" || "$DOWNLOAD_URL" == "null" ]]; then
+                echo "::error::Could not find Linux binary in the latest release. Please create a release with a Linux x64 binary."
+                exit 1
+              fi
+              
+              # Download the binary
+              echo "Downloading Linux binary from $DOWNLOAD_URL"
+              curl -L -o ./Docker/RewindSubtitleDisplayerForPlex_${VERSION}_linux-x64 $DOWNLOAD_URL
+              chmod +x ./Docker/RewindSubtitleDisplayerForPlex_${VERSION}_linux-x64
+            fi
           fi
 
       - name: Set up Docker Buildx

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ For manual setup, follow the instructions [here](https://github.com/ThioJoe/Plex
 2. Under the latest release, look in the `Assets` dropdown (expand if necessary) to see the available versions of the app
    - Refer to the "Which file below do I need?" info in the release notes above the assets
 
+## For Developers
+
+### GitHub Actions Workflows
+
+This repository includes GitHub Actions workflows to automate building, releasing, and Docker image publishing:
+
+1. **Build and Release Workflow**: Builds the application for multiple platforms and creates a GitHub release with the binaries.
+   - Manually triggered from the Actions tab
+   - Builds for Windows, Linux, and macOS
+   - Creates a GitHub release with the binaries
+
+2. **Docker Build and Publish Workflow**: Builds and publishes a Docker image to GitHub Container Registry.
+   - Automatically triggered when a new release is published
+   - Manually triggered from the Actions tab
+   - Publishes Docker images to `ghcr.io/thetechnetwork/plex-show-subtitles-on-rewind`
+
+For more details, see the [Workflows README](.github/workflows/README.md).
+
 ## Setup
 
 1.  **Connect to Plex**:


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to automate the build and release process:

- Adds `build-and-release.yml` workflow to build the application for multiple platforms (Windows, Linux, macOS) and create GitHub releases
- Uses OS-specific runners for each platform to avoid cross-OS compilation issues
- Updates the Docker workflow to download binaries from releases
- Updates documentation to explain the new workflows

This will make it easier to create releases with proper binaries that can be used by the Docker workflow.